### PR TITLE
fix: Revert to WAR packaging due to JSP access issues

### DIFF
--- a/.github/workflows/terracotta-bank-publish-release-package.yml
+++ b/.github/workflows/terracotta-bank-publish-release-package.yml
@@ -26,20 +26,20 @@ jobs:
       - name: Setup Gradle
         uses: gradle/actions/setup-gradle@ec92e829475ac0c2315ea8f9eced72db85bb337a # v3.0.0
 
-      - name: Build JAR with Gradle
+      - name: Build WAR with Gradle
         run: ./gradlew clean build -x test
 
-      - name: Copy JAR
+      - name: Copy WAR
         run: |
           TERRACOTTA_BANK_VERSION=0.0.1-SNAPSHOT
-          cp build/libs/terracotta-bank-servlet-${TERRACOTTA_BANK_VERSION}.jar terracotta.jar
+          cp build/libs/terracotta-bank-servlet-${TERRACOTTA_BANK_VERSION}.war terracotta.war
       
       - name: Upload Terracotta Bank Artifacts
         uses: actions/upload-artifact@v4
         with:
           name: terracotta-bank-artifacts
           path: |
-            terracotta.jar
+            terracotta.war
             scripts/
             docs/
 
@@ -51,7 +51,7 @@ jobs:
       - name: Install Dependencies
         run: sudo apt-get install -y libxml2-utils gnupg2
 
-      - name: Download Terracotta Bank JAR and Scripts
+      - name: Download Terracotta Bank WAR and Scripts
         uses: actions/download-artifact@v4
         with:
           name: terracotta-bank-artifacts
@@ -116,7 +116,7 @@ jobs:
         run: |
           LATEST_AGENT_RELEASE_VERSION=${{ steps.fetch-latest-contrast-agent-version.outputs.latest_agent_release_version }}
           mkdir -p terracotta-bank/docs
-          cp terracotta.jar terracotta-bank/terracotta.jar
+          cp terracotta.war terracotta-bank/terracotta.war
           cp contrast-agent.jar terracotta-bank/
           chmod u+x scripts/*.sh
           cp scripts/start.sh terracotta-bank/

--- a/Dockerfile
+++ b/Dockerfile
@@ -26,13 +26,13 @@ RUN gradle build -x test --stacktrace --no-daemon
 
 #
 # RUNTIME STAGE
-# Take only the compilied application .jar file form the build stage above and run it in a JRE container.
+# Take only the compilied application .war file form the build stage above and run it in a JRE container.
 #
 FROM openjdk:8-jre-alpine as runtime
-COPY --from=build /home/gradle/src/build/libs/terracotta-bank-servlet-0.0.1-SNAPSHOT.jar /app/terracotta-bank-servlet-0.0.1-SNAPSHOT.jar
+COPY --from=build /home/gradle/src/build/libs/terracotta-bank-servlet-0.0.1-SNAPSHOT.war /app/terracotta-bank-servlet-0.0.1-SNAPSHOT.war
 WORKDIR /app
 EXPOSE 8080
-CMD ["java", "-jar", "terracotta-bank-servlet-0.0.1-SNAPSHOT.jar"]
+CMD ["java", "-jar", "terracotta-bank-servlet-0.0.1-SNAPSHOT.war"]
 
 #
 # CONTRAST STAGE

--- a/build.gradle
+++ b/build.gradle
@@ -19,6 +19,7 @@ plugins {
     id 'java'
     id 'eclipse'
     id 'idea'
+    id 'war'
     id 'org.springframework.boot' version "${springBootVersion}"
     id 'io.spring.dependency-management' version '1.0.11.RELEASE'
     id 'com.google.cloud.tools.jib' version '3.2.1'

--- a/scripts/start.sh
+++ b/scripts/start.sh
@@ -254,7 +254,7 @@ start_application() {
         -Dcontrast.agent.polling.app_activity_ms=1000 \
         -javaagent:"$SCRIPT_DIR/contrast-agent.jar" \
         -Dserver.port="$PORT" \
-        -jar "$SCRIPT_DIR/terracotta.jar" >"$LOG_FILE" 2>&1 &
+        -jar "$SCRIPT_DIR/terracotta.war" >"$LOG_FILE" 2>&1 &
 
     wait_for_server "$PORT" "$ENVIRONMENT"
 }


### PR DESCRIPTION
## Description

This PR reverts the application packaging from JAR back to WAR format to resolve issues with accessing JSP files in the deployed application.

### Changes
- Reverted build.gradle to use WAR plugin
- Updated Dockerfile to handle WAR files
- Modified GitHub workflows to use WAR artifacts
- Updated start scripts to reference WAR instead of JAR